### PR TITLE
Enable renovate and track images in Makefile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+      "config:base"
+    ],
+    "regexManagers": [
+      {
+        "fileMatch": [
+          "^Makefile$"
+        ],
+        "matchStrings": [
+            "[A-Z_]+_IMAGE=(?<depName>.*?):(?<currentValue>.*?)\\n"
+        ],
+        "datasourceTemplate": "docker"
+      }
+    ]
+  }


### PR DESCRIPTION
This ensures that renovate is able to track images that we reference
from the Makefile. e.g. the buildkite-plugin-tester image.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
